### PR TITLE
Add texture background support for immersive messages

### DIFF
--- a/src/main/java/net/tysontheember/emberstextapi/immersivemessages/MessageCommands.java
+++ b/src/main/java/net/tysontheember/emberstextapi/immersivemessages/MessageCommands.java
@@ -194,6 +194,26 @@ public class MessageCommands {
                     msg.bgColor(tag.getString("bgColor"));
                 }
 
+                if (tag.contains("textureBackground", Tag.TAG_STRING)) {
+                    ResourceLocation texture = ResourceLocation.tryParse(tag.getString("textureBackground"));
+                    if (texture != null) {
+                        msg.textureBackground(texture);
+                    }
+                } else if (tag.contains("textureBackground", Tag.TAG_COMPOUND)) {
+                    CompoundTag tex = tag.getCompound("textureBackground");
+                    String key = tex.contains("location") ? "location" : tex.contains("texture") ? "texture" : null;
+                    ResourceLocation texture = key != null ? ResourceLocation.tryParse(tex.getString(key)) : null;
+                    if (texture != null) {
+                        int u = tex.contains("u") ? tex.getInt("u") : 0;
+                        int v = tex.contains("v") ? tex.getInt("v") : 0;
+                        int regionWidth = tex.contains("width") ? tex.getInt("width") : 256;
+                        int regionHeight = tex.contains("height") ? tex.getInt("height") : 256;
+                        int atlasWidth = tex.contains("atlasWidth") ? tex.getInt("atlasWidth") : regionWidth;
+                        int atlasHeight = tex.contains("atlasHeight") ? tex.getInt("atlasHeight") : regionHeight;
+                        msg.textureBackground(texture, u, v, regionWidth, regionHeight, atlasWidth, atlasHeight);
+                    }
+                }
+
                 if (tag.contains("borderColor")) {
                     ImmersiveColor border = parseImmersiveColor(tag.getString("borderColor"));
                     if (border != null) {


### PR DESCRIPTION
## Summary
- add texture background configuration and rendering to `ImmersiveMessage`, including network serialization
- allow `MessageCommands` to parse a `textureBackground` entry when building messages

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68caf906fa6483259ec6a2d10863473f