### PR TITLE
Fix immersive message timing to use client ticks

### DIFF
--- a/src/main/java/net/tysontheember/emberstextapi/immersivemessages/ClientEvents.java
+++ b/src/main/java/net/tysontheember/emberstextapi/immersivemessages/ClientEvents.java
@@ -1,7 +1,9 @@
 package net.tysontheember.emberstextapi.immersivemessages;
 
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.event.RenderGuiEvent;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.tysontheember.emberstextapi.EmbersTextAPI;
@@ -12,7 +14,17 @@ import net.tysontheember.emberstextapi.EmbersTextAPI;
 @Mod.EventBusSubscriber(modid = EmbersTextAPI.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public class ClientEvents {
     @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft == null || minecraft.isPaused()) return;
+
+        ImmersiveMessagesManager.tick();
+    }
+
+    @SubscribeEvent
     public static void onRenderGui(RenderGuiEvent.Post event) {
-        ImmersiveMessagesManager.render(event.getGuiGraphics(), event.getPartialTick());
+        ImmersiveMessagesManager.render(event.getGuiGraphics());
     }
 }


### PR DESCRIPTION
## Summary
- advance immersive message queueing and timing from the client tick event so typewriter/obfuscation speeds respect real ticks
- keep GUI rendering side-effect free and maintain a fixed 20-tick gap between queued messages

## Testing
- bash ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cb1b0149f08325a7dc5e86b4a3ce15